### PR TITLE
Poke multi-byte values directly rather than byte-at-a-time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,10 @@ script:
   - cabal new-build -w ${HC} ${TEST} ${BENCH} all
   - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
 
+  # build & run tests, build benchmarks this time with alignment friendly access
+  - cabal new-build -f force-aligned -w ${HC} ${TEST} ${BENCH} all
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -f force-aligned -w ${HC} ${TEST} ${BENCH} all; fi
+
   # cabal check
   - (cd persist-* && cabal check)
 

--- a/persist.cabal
+++ b/persist.cabal
@@ -25,12 +25,24 @@ source-repository head
   type:     git
   location: git://github.com/minad/persist
 
+flag force-unaligned
+        manual: True
+        default: False
+flag force-aligned
+        manual: True
+        default: False
+
 library
         default-language:       Haskell2010
 
-        build-depends:          base >= 4.4 && < 5, containers,
+        build-depends:          base >= 4.7 && < 5, containers,
                                 bytestring >= 0.10.4 && < 1,
                                 text >= 1.2 && < 1.3
+
+        if flag(force-unaligned) || arch(i386) || arch(x86_64)
+                cpp-options: -DUNALIGNED_MEMORY
+        if flag(force-aligned)
+                cpp-options: -DFORCE_ALIGNED_MEMORY
 
         hs-source-dirs:         src
 


### PR DESCRIPTION
This gives a modest performance improvement without compromising safety.

Bump required base version so that we are guaranteed to have fast byteswapping