### PR TITLE
Add support for older base (older stack snapshots)

### DIFF
--- a/src/Data/Persist.hs
+++ b/src/Data/Persist.hs
@@ -87,7 +87,9 @@ import qualified Data.ByteString.Short as S
 import qualified Data.ByteString.Short.Internal as S
 import qualified Data.Monoid as M
 import qualified Data.Text.Encoding as TE
+#if MIN_VERSION_containers(0,5,8)
 import qualified Data.Tree as T
+#endif
 
 #include "MachDeps.h"
 
@@ -791,7 +793,9 @@ instance Persist Text where
 instance Persist Bool
 instance Persist Ordering
 instance (Persist a) => Persist (Maybe a)
+#if MIN_VERSION_containers(0,5,8)
 instance Persist e => Persist (T.Tree e)
+#endif
 instance (Persist a, Persist b) => Persist (Either a b)
 instance (Persist a, Persist b) => Persist (a,b)
 instance (Persist a, Persist b, Persist c) => Persist (a,b,c)

--- a/src/Data/Persist/Internal.hs
+++ b/src/Data/Persist/Internal.hs
@@ -45,6 +45,9 @@ import Data.ByteString (ByteString)
 import Data.Foldable (foldlM)
 import Data.IORef
 import Data.List.NonEmpty (NonEmpty(..))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Monoid ((<>))
+#endif
 import Data.Word
 import Foreign (ForeignPtr, Ptr, plusPtr, minusPtr,
                 withForeignPtr, mallocBytes, free, allocaBytes)

--- a/tests/GetTests.hs
+++ b/tests/GetTests.hs
@@ -1,12 +1,16 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE CPP #-}
 
 module GetTests (tests) where
 
 import           Control.Applicative
 import           Control.Monad
 import           Data.Word
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Monoid ((<>))
+#endif
 import           Data.Function
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LB


### PR DESCRIPTION
Achieved with importing Monoid for older base and not importing Tree for older containers.

I specifically need it to work for lts-8.24, and it does with the changes.