### PR TITLE
A couple more additions before the 1.0.0.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,49 +34,49 @@ Results that are within 30% of the best result are displayed in **bold**.
 | ---| ---|
 | **persist**   |     **1.0** |
 | **store**     |     **1.1** |
-| **cereal**    |     **1.2** |
-| binary    |     7.2 |
-| serialise |     8.4 |
+| cereal    |     1.4 |
+| binary    |    10.5 |
+| serialise |    20.1 |
 
 #### deserialization (time)/BinTree Int (best first)
 
 | package | performance |
 | ---| ---|
 | **persist**   |     **1.0** |
-| **store**     |     **1.0** |
-| **cereal**    |     **1.2** |
-| binary    |     4.3 |
-| serialise |     5.0 |
+| **store**     |     **1.1** |
+| cereal    |     1.4 |
+| binary    |     5.3 |
+| serialise |    12.1 |
 
 #### deserialization (time)/Cars (best first)
 
 | package | performance |
 | ---| ---|
 | **persist**   |     **1.0** |
-| **store**     |     **1.3** |
+| **store**     |     **1.1** |
 | cereal    |     1.6 |
-| binary    |     8.0 |
-| serialise |     9.9 |
+| binary    |    12.2 |
+| serialise |    26.3 |
 
 #### deserialization (time)/Iris (best first)
 
 | package | performance |
 | ---| ---|
 | **persist**   |     **1.0** |
-| **store**     |     **1.2** |
-| cereal    |     3.0 |
-| serialise |     3.5 |
-| binary    |     7.6 |
+| **store**     |     **1.1** |
+| cereal    |     2.7 |
+| serialise |     7.7 |
+| binary    |    10.4 |
 
 #### deserialization (time)/[Direction] (best first)
 
 | package | performance |
 | ---| ---|
 | **persist**   |     **1.0** |
-| cereal    |     1.3 |
-| store     |     1.5 |
-| binary    |     4.4 |
-| serialise |     6.9 |
+| **store**     |     **1.1** |
+| **cereal**    |     **1.1** |
+| binary    |     5.5 |
+| serialise |    10.8 |
 
 #### serialization (time)/BinTree Direction (best first)
 
@@ -84,46 +84,46 @@ Results that are within 30% of the best result are displayed in **bold**.
 | ---| ---|
 | **persist**   |     **1.0** |
 | **store**     |     **1.1** |
-| cereal    |     8.2 |
-| binary    |    16.1 |
-| serialise |    26.4 |
+| cereal    |     7.9 |
+| binary    |    25.0 |
+| serialise |    45.1 |
 
 #### serialization (time)/BinTree Int (best first)
 
 | package | performance |
 | ---| ---|
-| **store**     |     **1.0** |
 | **persist**   |     **1.0** |
-| cereal    |    10.7 |
-| binary    |    18.3 |
-| serialise |    25.3 |
+| **store**     |     **1.3** |
+| cereal    |     9.8 |
+| binary    |    26.3 |
+| serialise |    35.5 |
 
 #### serialization (time)/Cars (best first)
 
 | package | performance |
 | ---| ---|
 | **store**     |     **1.0** |
-| persist   |     2.1 |
-| cereal    |     3.1 |
-| binary    |     9.0 |
-| serialise |    27.1 |
+| persist   |     1.4 |
+| cereal    |     3.0 |
+| binary    |    16.4 |
+| serialise |    44.4 |
 
 #### serialization (time)/Iris (best first)
 
 | package | performance |
 | ---| ---|
 | **store**     |     **1.0** |
-| persist   |     3.8 |
-| cereal    |     4.8 |
-| serialise |    21.4 |
-| binary    |    37.2 |
+| persist   |     1.4 |
+| cereal    |     2.8 |
+| serialise |    25.7 |
+| binary    |    29.8 |
 
 #### serialization (time)/[Direction] (best first)
 
 | package | performance |
 | ---| ---|
-| **store**     |     **1.0** |
-| persist   |     2.0 |
-| cereal    |     2.6 |
-| binary    |     2.9 |
-| serialise |     7.7 |
+| **persist**   |     **1.0** |
+| **store**     |     **1.2** |
+| cereal    |     3.7 |
+| binary    |     4.7 |
+| serialise |    14.4 |

--- a/src/Data/Persist.hs
+++ b/src/Data/Persist.hs
@@ -40,6 +40,7 @@ module Data.Persist
 
     -- * Serialization
   , encode
+  , encodeLazy
   , decode
 
     -- * The Get type
@@ -59,7 +60,9 @@ module Data.Persist
     -- * The Put type
   , Put
   , runPut
+  , runPutLazy
   , evalPut
+  , evalPutLazy
   , grow
   , putByteString
   , putHE
@@ -390,6 +393,11 @@ class Persist t where
 -- | Encode a value using binary serialization to a strict ByteString.
 encode :: (Persist a) => a -> ByteString
 encode = runPut . put
+
+-- | Encode a value using binary serialization to a lazy ByteString.
+encodeLazy :: (Persist a) => a -> L.ByteString
+encodeLazy = runPutLazy . put
+
 
 {- | Decode a value from a strict ByteString, reconstructing the original
 structure.
@@ -1136,6 +1144,10 @@ getPrefix prefixLength baseGet = do
 runPut :: Put a -> ByteString
 runPut = snd . evalPut
 {-# INLINE runPut #-}
+
+runPutLazy :: Put a -> L.ByteString
+runPutLazy = snd . evalPutLazy
+{-# INLINE runPutLazy #-}
 
 putByteString :: ByteString -> Put ()
 putByteString bs = do

--- a/tests/RoundTrip.hs
+++ b/tests/RoundTrip.hs
@@ -18,6 +18,7 @@ module RoundTrip where
 
 import qualified Data.ByteString as BS (length)
 import qualified Data.ByteString.Char8 as B8 (unpack)
+import qualified Data.ByteString.Lazy as LBS (toStrict)
 import Data.Int
 import Data.Persist
 import Data.Text (Text)
@@ -30,9 +31,10 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck as QC
 
 roundTrip :: (Persist a, Eq a) => (a -> Put ()) -> Get a -> a -> Bool
-roundTrip p g a = res == Right a
+roundTrip p g a = res == Right a && lazyRes == Right a
  where
   res = runGet (g <* eof) (runPut (p a))
+  lazyRes = runGet (g <* eof) (LBS.toStrict (runPutLazy (p a)))
 
 roundTripLengthInclusiveLE ::
   forall a l.


### PR DESCRIPTION
Potentially avoid a copy by using `reallocBytes` and registering a foreign pointer finalizer for small `Put`s.

Add Lazy encoding versions that can avoid copying completely.

Use length backpatching for the `[]` `Persist` instance.

Benchmarks are now much more competitive with `store`. 